### PR TITLE
feature / marginal diff calcs.

### DIFF
--- a/finx_option_pricer/bsm.py
+++ b/finx_option_pricer/bsm.py
@@ -4,6 +4,7 @@
 #
 import numpy as np
 from scipy.stats import norm
+from scipy.optimize import minimize_scalar
 
 N = norm.cdf
 N_prime = norm.pdf
@@ -75,3 +76,21 @@ def rho_call(S, K, T, r, sigma):
 
 def rho_put(S, K, T, r, sigma):
     return -K * T * np.exp(-r * T) * N(-d2(S, K, T, r, sigma))
+
+
+def implied_vol_call(opt_value, S, K, T, r):
+    # https://www.codearmo.com/python-tutorial/calculating-volatility-smile
+    def call_obj(sigma):
+        return abs(bs_call_value(S, K, T, r, sigma) - opt_value)
+
+    res = minimize_scalar(call_obj, bounds=(0.01, 6), method="bounded")
+    return res.x
+
+
+def implied_vol_put(opt_value, S, K, T, r):
+    # https://www.codearmo.com/python-tutorial/calculating-volatility-smile
+    def put_obj(sigma):
+        return abs(bs_put_value(S, K, T, r, sigma) - opt_value)
+
+    res = minimize_scalar(put_obj, bounds=(0.01, 6), method="bounded")
+    return res.x

--- a/finx_option_pricer/bsm.py
+++ b/finx_option_pricer/bsm.py
@@ -3,8 +3,8 @@
 # https://www.codearmo.com/python-tutorial/options-trading-greeks-black-scholes
 #
 import numpy as np
-from scipy.stats import norm
 from scipy.optimize import minimize_scalar
+from scipy.stats import norm
 
 N = norm.cdf
 N_prime = norm.pdf

--- a/finx_option_pricer/bsm.py
+++ b/finx_option_pricer/bsm.py
@@ -23,12 +23,14 @@ def bs_put_value(S, K, T, r, sigma):
 
 
 def bs_calldiv_value(S, K, T, r, q, sigma):
+    """Call with dividend value"""
     d1 = (np.log(S / K) + (r - q + sigma ** 2 / 2) * T) / (sigma * np.sqrt(T))
     d2 = d1 - sigma * np.sqrt(T)
     return S * np.exp(-q * T) * N(d1) - K * np.exp(-r * T) * N(d2)
 
 
 def bs_putdiv_value(S, K, T, r, q, sigma):
+    """Put with dividend value"""
     d1 = (np.log(S / K) + (r - q + sigma ** 2 / 2) * T) / (sigma * np.sqrt(T))
     d2 = d1 - sigma * np.sqrt(T)
     return K * np.exp(-r * T) * N(-d2) - S * np.exp(-q * T) * N(-d1)

--- a/finx_option_pricer/calcs.py
+++ b/finx_option_pricer/calcs.py
@@ -1,0 +1,38 @@
+import numpy as np
+import pandas as pd
+
+from finx_option_pricer.option import CALL, PUT, Option
+
+
+def calc_combined_call_put_iv(
+    S: float = None, K: float = None, call_price: float = None, put_price: float = None, time_days: int = None
+):
+    """Determine adjustment and Call/Put IV
+
+    Inputs:
+        S: Spot price
+        K: Strike price
+        call_price: executed call price
+        put_price: executed put price
+        time_days: DTE in (int) days
+
+    Returns:
+        Tuple: (price_adjustment, call_iv, put_iv)
+    """
+    fd = dict(T=time_days / 252.0, r=0.0, S=S, K=K, sigma=None)
+    fc = {**fd, **dict(option_type=CALL)}
+    fp = {**fd, **dict(option_type=PUT)}
+    fco = Option(**fc)
+    fpo = Option(**fp)
+    results = []
+    for i in range(0, 60):
+        civ = fco.iv(call_price - i)
+        piv = fpo.iv(put_price + i)
+        results.append((i, civ, piv))
+
+    df = pd.DataFrame(results, columns=["diff", "iv_call", "iv_put"]).set_index("diff")
+    df["iv_diff"] = df["iv_call"] - df["iv_put"]
+    pa = df[np.sign(df["iv_diff"]).diff().fillna(0).ne(0)].copy().index[0]
+    fciv = fco.iv(call_price - pa)
+    fpiv = fpo.iv(put_price + pa)
+    return (pa, fciv, fpiv)

--- a/finx_option_pricer/calcs.py
+++ b/finx_option_pricer/calcs.py
@@ -4,7 +4,7 @@ import pandas as pd
 from finx_option_pricer.option import CALL, PUT, Option
 
 
-def calc_combined_call_put_iv(
+def calc_straddle_iv(
     S: float = None, K: float = None, call_price: float = None, put_price: float = None, time_days: int = None
 ):
     """Determine adjustment and Call/Put IV

--- a/finx_option_pricer/option.py
+++ b/finx_option_pricer/option.py
@@ -17,7 +17,7 @@ class Option:
     @property
     def _t_days(self) -> int:
         """Time in days"""
-        return int(self.T * 365)
+        return int(self.T * 252)
 
     @property
     def id(self) -> str:

--- a/finx_option_pricer/option.py
+++ b/finx_option_pricer/option.py
@@ -3,6 +3,10 @@ from dataclasses import dataclass
 import finx_option_pricer.bsm as bsm
 
 
+CALL = "c"
+PUT = "p"
+
+
 @dataclass
 class Option:
     S: float  # current price

--- a/finx_option_pricer/option.py
+++ b/finx_option_pricer/option.py
@@ -49,6 +49,14 @@ class Option:
         elif self.option_type == "p":
             return max(self.K - price, 0.0)
 
+    def iv(self, opt_value: float) -> float:
+        """Calculated Implied Volatility based on opt_price"""
+        if self.option_type == CALL:
+            return bsm.implied_vol_call(opt_value, self.S, self.K, self.T, self.r)
+        if self.option_type == PUT:
+            return bsm.implied_vol_put(opt_value, self.S, self.K, self.T, self.r)
+        raise ValueError(f"Must select either c or p (for call or put). Presently, self.option_type={self.option_type}")
+
     @property
     def break_even_value(self) -> float:
         """Break even value for option

--- a/finx_option_pricer/option.py
+++ b/finx_option_pricer/option.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 
 import finx_option_pricer.bsm as bsm
 
-
 CALL = "c"
 PUT = "p"
 

--- a/finx_option_pricer/option_plot.py
+++ b/finx_option_pricer/option_plot.py
@@ -24,6 +24,10 @@ class OptionPosition:
         qty = abs(self.quantity)
         return f"{self.option.id}-{side}{qty}"
 
+    @property
+    def initial_value(self) -> float:
+        return self.option.value * self.quantity
+
     def interpolated_vol(self, fraction: float) -> float:
         """Using the start and end IV, calc the linear interpolated IV"""
         assert self.end_sigma is not None, "end_sigma must be not None"
@@ -129,7 +133,8 @@ class OptionsPlot:
 
                 aggregate_position_value_wrt_strikes.append(option_position_strike_values)
 
-            results[newDays] = np.sum(aggregate_position_value_wrt_strikes, axis=0) - __initial_value
+            agg_value_sum = np.sum(aggregate_position_value_wrt_strikes, axis=0)
+            results[newDays] = agg_value_sum - __initial_value if value_relative is True else agg_value_sum
 
         # determine final value at expiration of nearest dated option
         #

--- a/finx_option_pricer/option_plot.py
+++ b/finx_option_pricer/option_plot.py
@@ -80,7 +80,7 @@ class OptionsPlot:
 
         # NOTE - only look as far as the shortest dated option
         min_time = min([op.option.T for op in self.option_positions])
-        min_days = int(min_time * MARKET_DAYS_PER_YEAR)
+        min_days = int(min_time * market_days_year)
 
         _start = self.spot_range[0]
         _end = self.spot_range[1] + self.strike_interval
@@ -94,7 +94,7 @@ class OptionsPlot:
             if day >= min_days:
                 continue
 
-            annualized_days = day / MARKET_DAYS_PER_YEAR
+            annualized_days = day / market_days_year
 
             #
             # TODO - This could use a good refactoring. Too much going on at once
@@ -103,7 +103,7 @@ class OptionsPlot:
             for option_position in self.option_positions:
                 newT = option_position.option.T - annualized_days
 
-                newDays = int(newT * MARKET_DAYS_PER_YEAR)
+                newDays = int(newT * market_days_year)
 
                 # if the "option_position" has an end_sigma non None value, this means the option's sigma/vol
                 # is expected to linearly change as the option progresses to expiration. For example,
@@ -144,7 +144,7 @@ class OptionsPlot:
                 option_position_strike_values = []
                 for price in strike_range:
                     value = None
-                    if newT <= 1 / MARKET_DAYS_PER_YEAR:
+                    if newT <= 1 / market_days_year:
                         # option has expired - determine final value
                         value = option_position.option.final_value(price) * option_position.quantity
 

--- a/finx_option_pricer/option_plot.py
+++ b/finx_option_pricer/option_plot.py
@@ -50,7 +50,9 @@ class OptionsPlot:
 
     # flake8: noqa: C901
     # TODO - resolve C901 issue
-    def gen_value_df_timeincrementing(self, days: int, step: int = 1, show_final: bool = True) -> pd.DataFrame:
+    def gen_value_df_timeincrementing(
+        self, days: int, step: int = 1, show_final: bool = True, market_days_year: int = 252, value_relative=True
+    ) -> pd.DataFrame:
         """Generate value option positions as they decay with time.
 
         Example return,
@@ -65,6 +67,8 @@ class OptionsPlot:
             days (int): number days to increment over.
             step (int, optional): step or increment interval. Defaults to 1.
             show_final (bool, optional): option(s) value at expiration of nearest data option. Defaults to True.
+            market_days_year(int): number of market days in a calendar year. Defaults to 252.
+            value_relative(boolean): value the options package with respect to initial value vs absolute value. Defaults to True.
 
         Returns:
             (pd.DataFrame): DataFrame with columns [strikes, days-step1, days-step2, ..., expiration]
@@ -159,7 +163,9 @@ class OptionsPlot:
                     option_position_strike_values.append(value)
 
                 option_positions_values.append(option_position_strike_values)
-            results[0] = list(np.sum(option_positions_values, axis=0)) - __initial_value
+
+            agg_value_sum = list(np.sum(option_positions_values, axis=0))
+            results[0] = agg_value_sum - __initial_value if value_relative is True else agg_value_sum
 
         # return values as DataFrame
         return pd.DataFrame(results)

--- a/tests/test_calcs.py
+++ b/tests/test_calcs.py
@@ -1,13 +1,13 @@
 import numpy as np
 
-from finx_option_pricer.calcs import calc_combined_call_put_iv
+from finx_option_pricer.calcs import calc_straddle_iv
 
 
-def test_calc_combined_call_put_iv():
+def test_calc_straddle_iv():
     # got these numbers from IB for the /ES options
     S = 4095.0
     K = 4150.0
-    fa, civ, piv = calc_combined_call_put_iv(S=S, K=K, call_price=108.5, put_price=80.25, time_days=16)
+    fa, civ, piv = calc_straddle_iv(S=S, K=K, call_price=108.5, put_price=80.25, time_days=16)
 
     expected_civ = 0.220535
     expected_piv = 0.222397

--- a/tests/test_calcs.py
+++ b/tests/test_calcs.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+from finx_option_pricer.calcs import calc_combined_call_put_iv
+
+
+def test_calc_combined_call_put_iv():
+    # got these numbers from IB for the /ES options
+    S = 4095.0
+    K = 4150.0
+    fa, civ, piv = calc_combined_call_put_iv(S=S, K=K, call_price=108.5, put_price=80.25, time_days=16)
+
+    expected_civ = 0.220535
+    expected_piv = 0.222397
+    expected_fa = 42
+
+    assert fa == expected_fa
+    np.testing.assert_almost_equal(civ, expected_civ, decimal=3)
+    np.testing.assert_almost_equal(piv, expected_piv, decimal=3)


### PR DESCRIPTION
changes:
- add Option.iv method to back out implied vol
- add straddle iv calc method (helpful for calcing IV of transacted options)
- use market days = 252 throughout codebase.